### PR TITLE
Fix https://github.com/Depixelation/Global-Wind/issues/10

### DIFF
--- a/src/main/java/colossalrenders/globalwind/GlobalWind.java
+++ b/src/main/java/colossalrenders/globalwind/GlobalWind.java
@@ -1,5 +1,6 @@
 package colossalrenders.globalwind;
 
+import colossalrenders.globalwind.config.ModConfigs;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
@@ -46,6 +47,8 @@ public class GlobalWind implements ModInitializer {
 			});
 			
 		});
+
+		ModConfigs.registerConfigs();
 	}
 
 	private static SoundEvent registerSound(String id) {


### PR DESCRIPTION
Fixes issue https://github.com/Depixelation/Global-Wind/issues/10. It seems like the issue was just that the config wasn't registered, which means no value was ever being assigned to ModConfigs.WIND_MULTIPLIER_CONFIG, so it was left at the default double value of 0.0. As a result, wind calculations were being performed, but always came out to no wind at all, so entities and the sound system were never affected.

It turned out to be a 1-line fix, so not too bad!